### PR TITLE
Replace deprecated normed=True with density=True in np.histogram() call.

### DIFF
--- a/src/double_jpeg_compression.py
+++ b/src/double_jpeg_compression.py
@@ -50,7 +50,7 @@ def detect(input):
     for idx,ax in enumerate(a1):
         k+=1;
         data = qDCT[:,int(idx/8),int(idx%8)]
-        val,key = np.histogram(data, bins=np.arange(data.min(), data.max()+1),normed = True)
+        val, _ = np.histogram(data, bins=np.arange(data.min(), data.max()+1), density = True)
         z = np.absolute(fftp.fft(val))
         z = np.reshape(z,(len(z),1))
         rotz = np.roll(z,int(len(z)/2))


### PR DESCRIPTION
The `normed=True ` argument has been deprecated in numpy.
Calling it results in the following warning:
```
Passing `normed=True` on non-uniform bins has always been broken, and computes neither the probability density function nor the probability mass function. The result is only correct if the bins are uniform, when density=True will produce the same result anyway. The argument will be removed in a future version of numpy.
```
I have replaced the argument with `density=True`.